### PR TITLE
0.8.3.3 - JWST Desktop Init

### DIFF
--- a/jwst/templates/jwst.html
+++ b/jwst/templates/jwst.html
@@ -11,39 +11,42 @@
     </div>
 </div>
 {% endblock %} {% block laydo_content_1 %}
-<div class="jwst-section laydo-container">
-  <div class="container-title">James Webb Space Telescope</div>
-  <div class="jwst-row-info laydo-container" id="jwstDisplay">
-    
-    <!-- <div class="jwst-row-info"> -->
-      <div class="jwst-side-info">
-        <div class="jwst-col-info">
-          <h3 id="targetTitle">TARGET NAME</h3>
-          <div class="info-sec" id="targetName">--</div>
+<div class="laydo-container">
+  <div class="jwst-flipper">
+    <div class="jwst-col-info">
+      <div class="container-title">James Webb Space Telescope</div>
+      <div class="jwst-row-info laydo-container" id="jwstDisplay">
+        <div class="jwst-side-info">
+          <div class="jwst-col-info">
+            <h3 id="targetTitle">TARGET NAME</h3>
+            <div class="info-sec" id="targetName">--</div>
+          </div>
+          <div class="jwst-col-info">
+            <h3>CATEGORIES</h3>
+            <div class="info-sec" id="categoryKeywords">--</div>
+          </div>
         </div>
-        <div class="jwst-col-info">
-          <h3>CATEGORIES</h3>
-          <div class="info-sec" id="categoryKeywords">--</div>
+        <div class="jwst-wrapper" id="jwstIcon">
+          <svg id="jwstSVG" width="100" height="100" viewBox="0 0 225 225" ></svg>
+        </div>
+        <div class="jwst-side-info">
+          <div class="jwst-col-info">
+            <h3>INSTRUMENTS</h3>
+            <div class="info-sec" id="instruments">--</div>
+          </div>
+          <div class="jwst-col-info">
+            <h3 id="timeTitles">SCHEDULE</h3>
+            <div class="info-sec" id="startTimeTimes">--</div>
+          </div>
         </div>
       </div>
-      <div class="jwst-wrapper" id="jwstIcon">
-        <svg id="jwstSVG" width="100" height="100" viewBox="0 0 225 225" ></svg>
-      </div>
-      <div class="jwst-side-info">
-        <div class="jwst-col-info">
-          <h3>INSTRUMENTS</h3>
-          <div class="info-sec" id="instruments">--</div>
-        </div>
-        <div class="jwst-col-info">
-          <h3 id="timeTitles">SCHEDULE</h3>
-          <div class="info-sec" id="startTimeTimes">--</div>
-        </div>
-      </div>
-    <!-- </div> -->
+    </div>
+    <div class="jwst-col-info">
+      <div id="scrollDate" class="container-title"></div>
+      <div class="iteration" id="iterateTarget"></div>
+    </div>
   </div>
-  <div id="scrollDate" class="container-title"></div>
-  <div class="iteration" id="iterateTarget">
-  </div>
+  
 </div>
 {% endblock %}
 {% block page_scripts %}

--- a/static/base/css/base.css
+++ b/static/base/css/base.css
@@ -118,7 +118,7 @@ body {
 
 #laydoHomeOne,
 #laydoHomeTwo {
-  min-height: 100vh;
+  min-height: 80vh;
 }
 
 .laydo-title,

--- a/static/jwst/css/jwst.css
+++ b/static/jwst/css/jwst.css
@@ -19,6 +19,14 @@
     align-items: center;
 }
 
+.jwst-row-info {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    height: 100%;
+    width: 100%;
+}
+
 .jwst-col-info {
     display: flex;
     flex-direction: column;
@@ -30,7 +38,6 @@
     display: flex;
     flex-direction: column;
     justify-content: space-around;
-    align-items: center;
     height: 100%;
     padding: 0 0.125rem;
 }
@@ -44,14 +51,6 @@
     flex-direction: column;
     justify-content: center;
     height: 100%;
-}
-
-.jwst-row-info {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-    height: 100%;
-    width: 100%;
 }
 
 #jwstInfo {
@@ -124,6 +123,7 @@
     justify-content: space-around;
     align-items: center;
     height: 100%;
+    font-size: 0.75rem;
 }
 
 .times {
@@ -153,10 +153,25 @@
     display: none;
 }
 
-@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+.jwst-flipper {
+    display: flex;
+    flex-direction: column;
+}
 
-    .times,
-    .target {
-        font-size: 0.75rem;
+@media only screen and (min-device-width: 600px) {
+    .jwst-flipper {
+        flex-direction: row;
+        justify-content: space-evenly;
+    }
+    .jwst-col-info {
+        width: 100%;
+    }
+    #jwstDisplay,
+    .iteration {
+        height: 80vh;
+    }
+    #jwstSVG {
+        height: 250;
+        width: 250;
     }
 }

--- a/static/jwst/js/jwst.js
+++ b/static/jwst/js/jwst.js
@@ -116,6 +116,10 @@ class JWSTTelescope {
             poly.style.stroke = 'black';
             poly.style.strokeWidth = 3;
             svg.append(poly);
+            if (window.matchMedia('(min-device-width: 600px)').matches) {
+                svg.setAttribute('width', '250');
+                svg.setAttribute('height', '250');
+            }
 
         }
         document.getElementById('jwstIcon').addEventListener('click', this.scrolls);


### PR DESCRIPTION
- Beginning to layout desktop version of JWST app
- Modified base css to accomodate main app area at 80vh, might lower
- Flipping to desktop at 600px, controlled by jwst-flipper
- May need to bring desktop/mobile flipping to base/app level
- A little JS media matching to scale SVG