### PR TITLE
Sports 0.5 - Team Pages Init

### DIFF
--- a/sports/templates/team.html
+++ b/sports/templates/team.html
@@ -1,0 +1,18 @@
+{% extends "app.html" %} {% load static %} {% block page_head %}
+<link rel="stylesheet" href="{% static 'sports/css/sports.css' %}" />
+{% endblock %}
+{% block laydo_content_1 %}
+<div id="context-data" style="display:none;" data-team-id="{{ id }}" data-league="{{ league }}"
+    data-name="{{ name }}" data-logo="{{ logo }}"
+    data-color="{{ color }}" data-alt-color="{{ alternateColor }}" data-record="{{ record }}"
+    data-standing="{{ standing }}" data-next-event="{{ nextEvent }}" data-next-event-date="{{ nextEventDate }}"
+    data-next-event-broadcast="{{ nextEventBroadcast }}">
+</div>
+<div id="sportsTeamPage" class="laydo-app team-container"></div>
+{% endblock %}
+{% block laydo_footer %}
+<div id="credits" class="sub-data">Sports data provided by <a href="https://www.espn.com">ESPN</a></div>
+{% endblock %}
+{% block page_scripts %}
+<script type="module" src="{% static '/dist/sports.bundle.js' %}"></script>
+{% endblock %}

--- a/sports/urls.py
+++ b/sports/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('nfl/<int:id>/', views.getNFLTeam, name='getNFLTeam'),
     path('college-football/<int:id>/', views.getCollegeFootballTeam, name='getCollegeFootballTeam'),
     path('mlb/<int:id>/', views.getMLBTeam, name='getMLBTeam'),
+    path('<str:league>/team/<int:id>/', views.team, name='showTeam'),
 ]

--- a/sports/views.py
+++ b/sports/views.py
@@ -12,6 +12,17 @@ MLB_TEAM_URL = "https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/teams
 def sports(request):
     return render(request, "sports.html")
 
+def team(request, league: str, id: int):
+    if league == "nfl":
+        teamData = getNFLTeam(request, id)
+    elif league == "college-football":
+        teamData = getCollegeFootballTeam(request, id)
+    elif league == "mlb":
+        teamData = getMLBTeam(request, id)
+    # Convert the JsonResponse to a dictionary
+    teamData = json.loads(teamData.content)
+    return render(request, "team.html", teamData)
+
 class BaseTeam(ABC, View):
     @property
     @abstractmethod

--- a/static/sports/css/sports.css
+++ b/static/sports/css/sports.css
@@ -1,3 +1,4 @@
+/* Sports Widget Classes */
 .sports-widget {
     background-color: var(--glass-backdrop);
     padding: 10px;
@@ -24,24 +25,125 @@
     display: block;
 }
 
-.team-name {
-    text-align: center;
-    font-size: 1.5em;
-}
-
-.team-record-standing {
+.sports-record-standing {
     display: flex;
     flex-direction: column;
 }
 
-.team-record {
+.sports-record {
     text-align: center;
     font-size: 1.5rem;
 }
 
-.team-standing {
+.sports-standing {
     text-align: center;
     font-size: 1rem;
+}
+.sports-next-event-date {
+    text-align: center;
+    font-size: 0.75rem;
+}
+
+.sports-next-event-opponent {
+    text-align: center;
+    font-size: 1.25rem;
+}
+
+.sports-next-event-broadcast {
+    text-align: center;
+    font-size: 0.75rem;
+}
+
+/* Team Page Classes */
+.team-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: start;
+    align-items: center;
+    border-top: 0.125rem solid var(--font-color);
+    border-right: 0.125rem solid var(--font-color);
+    border-left: 0.125rem solid var(--font-color);
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+    width: 94%;
+    padding: 1rem;
+}
+
+.team-logo {
+    width: 200px;
+    height: 200px;
+    border-radius: 1rem;
+    margin-right: 1.5rem;
+    display: block;
+}
+
+.team-name {
+    text-align: center;
+    font-size: 2em;
+}
+
+.team-header-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: start;
+}
+
+.team-record {
+    text-align: center;
+    font-size: 1.25rem;
+    margin-right: 1rem;
+}
+
+.team-standing {
+    text-align: center;
+    font-size: 0.75rem;
+}
+
+.team-record-standing {
+    display: flex;
+    flex-direction: row;
+    justify-content: start;
+    align-items: center;
+}
+
+.team-body {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    border-right: 0.125rem solid var(--font-color);
+    border-left: 0.125rem solid var(--font-color);
+    border-bottom: 0.125rem solid var(--font-color);
+    border-bottom-left-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+    width: 94%;
+    background-color: var(--color-primary);
+    padding: 1rem;
+}
+
+.team-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.team-next-event-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 49%;
+    background-color: var(--glass-backdrop);
+    min-height: 35rem;
+}
+
+.team-next-event {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
 .team-next-event-date {
@@ -59,11 +161,58 @@
     font-size: 0.75rem;
 }
 
+.team-season-results-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 49%;
+    background-color: var(--glass-backdrop);
+    min-height: 35rem;
+}
+
+.team-standings-container,
+.team-schedule-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 0.125rem solid var(--font-color);
+    background-color: var(--glass-backdrop);
+    width: 96%;
+}
+
+.team-standings-container {
+    min-height: 15vh;
+}
+.team-schedule-container {
+    height: 35vh;
+}
+
 @media only screen and (max-width: 48rem) {
     .sports-widget {
         width: 80%;
     }
-    
+
+    .team-next-event-container,
+    .team-season-results-container {
+        min-height: 25rem;
+        width: 100%;
+    }
+    .team-body {
+        flex-direction: column;
+    }
+    .team-logo {
+        width: 100px;
+        height: 100px;
+    }
+    .team-name {
+        font-size: 1.25em;
+    }
+    .team-header,
+    .team-body {
+        width: 88%;
+    }
 }
 
 @keyframes loadingShimmer {

--- a/static/sports/js/SportsWidgets.ts
+++ b/static/sports/js/SportsWidgets.ts
@@ -67,32 +67,34 @@ export class TeamWidget extends SportsWidget {
         this.teamNextEventBroadcast = '';
 
         this.recordStandingElement = document.createElement('div');
-        this.recordStandingElement.classList.add('team-record-standing');
+        this.recordStandingElement.classList.add('sports-record-standing');
         this.widget.appendChild(this.recordStandingElement);
 
         this.recordElement = document.createElement('div');
-        this.recordElement.classList.add('team-record');
+        this.recordElement.classList.add('sports-record');
         this.recordStandingElement.appendChild(this.recordElement);
 
         this.standingElement = document.createElement('div');
-        this.standingElement.classList.add('team-standing');
+        this.standingElement.classList.add('sports-standing');
         this.recordStandingElement.appendChild(this.standingElement);
 
         this.nextEventElement = document.createElement('div');
-        this.nextEventElement.classList.add('team-next-event');
+        this.nextEventElement.classList.add('sports-next-event');
         this.widget.appendChild(this.nextEventElement);
 
         this.nextEventDateElement = document.createElement('div');
-        this.nextEventDateElement.classList.add('team-next-event-date');
+        this.nextEventDateElement.classList.add('sports-next-event-date');
         this.nextEventElement.appendChild(this.nextEventDateElement);
 
         this.nextEventOpponentElement = document.createElement('div');
-        this.nextEventOpponentElement.classList.add('team-next-event-opponent');
+        this.nextEventOpponentElement.classList.add('sports-next-event-opponent');
         this.nextEventElement.appendChild(this.nextEventOpponentElement);
 
         this.nextEventBroadcastElement = document.createElement('div');
-        this.nextEventBroadcastElement.classList.add('team-next-event-broadcast');
+        this.nextEventBroadcastElement.classList.add('sports-next-event-broadcast');
         this.nextEventElement.appendChild(this.nextEventBroadcastElement);
+
+        this.widget.addEventListener('click', () => this.openTeamPage());
 
         this.fetchData(this.teamId, this.teamLeague);
     }
@@ -142,6 +144,10 @@ export class TeamWidget extends SportsWidget {
         this.widget.style.backgroundColor = `#${this.teamColor}`;
         this.widget.style.borderColor = `#${this.teamAltColor}`;
         this.widget.classList.remove("sports-widget-loading");
+    }
+
+    openTeamPage() {
+        window.location.pathname = `sports/${this.teamLeague}/team/${this.teamId}/`;
     }
 }
 

--- a/static/sports/js/TeamPage.ts
+++ b/static/sports/js/TeamPage.ts
@@ -1,0 +1,145 @@
+const options: Intl.DateTimeFormatOptions = {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+};
+
+export class TeamPage {
+    // Supplied container element, everything appends to this
+    container: HTMLElement;
+
+    // Elements for the header
+    headerElement: HTMLElement;
+    bodyElement: HTMLElement;
+    logoElement: HTMLImageElement;
+    headerInfoElement: HTMLElement;
+    teamNameElement: HTMLElement;
+    recordStandingElement: HTMLElement;
+    recordElement: HTMLElement;
+    standingElement: HTMLElement;
+
+    // Elements for the body
+
+    // Elements for the next event
+    nextEventContainer: HTMLElement;
+    nextEventElement: HTMLElement;
+    nextEventDateElement: HTMLElement;
+    nextEventBroadcastElement: HTMLElement;
+
+    // Elements for season results
+    seasonResultsContainer: HTMLElement;
+    standingsContainer: HTMLElement;
+    scheduleContainer: HTMLElement;
+
+    // Data
+    teamName: string;
+    logo: string;
+    league: string;
+    record: string;
+    standing: string;
+    nextEvent: string;
+    nextEventDate: string;
+    nextEventBroadcast: string;
+    color: string;
+    altColor: string;
+
+    constructor(container: HTMLElement, data: any) {
+        console.log('TeamPage');
+        this.container = container;
+
+        this.headerElement = document.createElement('div');
+        this.headerElement.classList.add('team-header');
+        this.container.appendChild(this.headerElement);
+
+        this.logoElement = document.createElement('img');
+        this.logoElement.classList.add('team-logo');
+        this.headerElement.appendChild(this.logoElement);
+
+        this.headerInfoElement = document.createElement('div');
+        this.headerInfoElement.classList.add('team-header-info');
+        this.headerElement.appendChild(this.headerInfoElement);
+
+        this.teamNameElement = document.createElement('div');
+        this.teamNameElement.classList.add('team-name');
+        this.headerInfoElement.appendChild(this.teamNameElement);
+
+        this.recordStandingElement = document.createElement('div');
+        this.recordStandingElement.classList.add('team-record-standing');
+        this.headerInfoElement.appendChild(this.recordStandingElement);
+
+        this.recordElement = document.createElement('div');
+        this.recordElement.classList.add('team-record');
+        this.recordStandingElement.appendChild(this.recordElement);
+
+        this.standingElement = document.createElement('div');
+        this.standingElement.classList.add('team-standing');
+        this.recordStandingElement.appendChild(this.standingElement);
+        
+        this.bodyElement = document.createElement('div');
+        this.bodyElement.classList.add('team-body');
+        this.container.appendChild(this.bodyElement);
+
+        this.nextEventContainer = document.createElement('div');
+        this.nextEventContainer.classList.add('team-next-event-container');
+        this.bodyElement.appendChild(this.nextEventContainer);
+
+        this.nextEventElement = document.createElement('div');
+        this.nextEventElement.classList.add('team-next-event');
+        this.nextEventContainer.appendChild(this.nextEventElement);
+
+        this.nextEventDateElement = document.createElement('div');
+        this.nextEventDateElement.classList.add('team-next-event-date');
+        this.nextEventContainer.appendChild(this.nextEventDateElement);
+
+        this.nextEventBroadcastElement = document.createElement('div');
+        this.nextEventBroadcastElement.classList.add('team-next-event-broadcast');
+        this.nextEventContainer.appendChild(this.nextEventBroadcastElement);
+
+        this.seasonResultsContainer = document.createElement('div');
+        this.seasonResultsContainer.classList.add('team-season-results-container');
+        this.bodyElement.appendChild(this.seasonResultsContainer);
+
+        this.standingsContainer = document.createElement('div');
+        this.standingsContainer.classList.add('team-standings-container');
+        this.standingsContainer.innerText = 'Standings';
+        this.seasonResultsContainer.appendChild(this.standingsContainer);
+
+        this.scheduleContainer = document.createElement('div');
+        this.scheduleContainer.classList.add('team-schedule-container');
+        this.scheduleContainer.innerText = 'Schedule';
+        this.seasonResultsContainer.appendChild(this.scheduleContainer);
+
+        // Convert UTC date to local date
+        let utcDate = new Date(data.dataset.nextEventDate);
+        let localDate = utcDate.toLocaleString('en-US', options);
+
+        this.teamName = data.dataset.name || '';
+        this.logo = data.dataset.logo || '';
+        this.league = data.dataset.league || '';
+        this.record = data.dataset.record || '';
+        this.standing = data.dataset.standing || '';
+        this.nextEvent = data.dataset.nextEvent || '';
+        this.nextEventDate = localDate || '';
+        this.nextEventBroadcast = data.dataset.nextEventBroadcast || '';
+        this.color = data.dataset.color || '';
+        this.altColor = data.dataset.altColor || '';
+
+        this.populatePage();
+    }
+
+    populatePage() {
+        this.logoElement.src = this.logo;
+        this.teamNameElement.innerText = this.teamName;
+        this.recordElement.innerText = this.record;
+        this.standingElement.innerText = this.standing;
+        this.nextEventElement.innerText = this.nextEvent;
+        this.nextEventDateElement.innerText = this.nextEventDate;
+        this.nextEventBroadcastElement.innerText = this.nextEventBroadcast;
+
+        this.headerElement.style.backgroundImage = `linear-gradient(#${this.color} 70%, var(--color-primary) 100%)`;
+        this.headerElement.style.borderColor = `#${this.altColor}`;
+        this.bodyElement.style.borderColor = `#${this.altColor}`;
+    }
+}

--- a/static/sports/js/sports.ts
+++ b/static/sports/js/sports.ts
@@ -4,6 +4,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let sportsContainer = document.getElementById('sportsElements');
     if (sportsContainer) {
         let packers = new NFLTeamWidget(sportsContainer, 9);
+        let seahawks = new NFLTeamWidget(sportsContainer, 26);
+        let bears = new NFLTeamWidget(sportsContainer, 3);
         let cougars = new CollegeFootballTeamWidget(sportsContainer, 265);
         let mariners = new MLBTeamWidget(sportsContainer, 12);
     }

--- a/static/sports/js/team.ts
+++ b/static/sports/js/team.ts
@@ -1,0 +1,9 @@
+import { TeamPage } from './TeamPage';
+
+document.addEventListener('DOMContentLoaded', () => {
+    let teamContainer = document.getElementById('sportsTeamPage');
+    let contextData = document.getElementById('context-data');
+    if (teamContainer && contextData) {
+        let team = new TeamPage(teamContainer, contextData);
+    }
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
         webgl: ['./static/webgl/js/WebGL.ts', './static/webgl/js/webbers.js', './static/webgl/js/init-buffers.js', './static/webgl/js/draw-scene.js'],
         ai: ['./static/ai/js/chat.js'],
         cookbook: ['./static/cookbook/js/cooky.ts', './static/cookbook/js/cookbook.ts', './static/cookbook/js/Recipe.ts'],
-        sports: ['./static/sports/js/sports.ts', './static/sports/js/SportsWidgets.ts'],
+        sports: ['./static/sports/js/sports.ts', './static/sports/js/SportsWidgets.ts', './static/sports/js/team.ts', './static/sports/js/TeamPage.ts'],
     },
     mode: 'development',
     cache: false,


### PR DESCRIPTION
- Implemented foundation for Team Pages
- Clicking on Sports Widget leads to Team Page
- Header displaying basic team info
- Body displays next event and season results
- Next Event info on left, responsive
- Season results on right, displaying standings and schedule outcomes
- Temporary layout designs showing until finalized
- Now including bears and seahawks