### PR TITLE
[codex] Add RainViewer radar layer

### DIFF
--- a/src/lib/client/weather.ts
+++ b/src/lib/client/weather.ts
@@ -82,6 +82,19 @@ type AirQualityData = {
   };
 };
 
+type RainViewerFrame = {
+  time: number;
+  path: string;
+};
+
+type RainViewerWeatherMaps = {
+  host?: string;
+  radar?: {
+    past?: RainViewerFrame[];
+    nowcast?: RainViewerFrame[];
+  };
+};
+
 type WeatherPayload = {
   aqi: AirQualityData;
   city: GeocodingResult;
@@ -106,6 +119,8 @@ type CelestialEvent = {
 
 const unitStorageKey = "laydonet-weather-unit";
 const hourMs = 60 * 60 * 1000;
+const rainViewerMapsUrl = "https://api.rainviewer.com/public/weather-maps.json";
+const rainViewerRefreshMs = 10 * 60 * 1000;
 
 const weatherCodes: Record<number, { kind: WeatherKind; label: string }> = {
   0: { kind: "clear", label: "Clear sky" },
@@ -282,12 +297,49 @@ const fetchJson = async <T,>(url: string, signal?: AbortSignal) => {
 
 let map: L.Map | null = null;
 let marker: L.CircleMarker | null = null;
+let radarLayer: L.TileLayer | null = null;
+let radarLayerLoadedAt = 0;
+let radarLayerRequest: Promise<void> | null = null;
 let activeRequest = 0;
 let activeController: AbortController | null = null;
 let celestialTimer: number | undefined;
 let lastCity = "Chicago";
 let lastRequest: WeatherRequest = { kind: "city", cityName: lastCity };
 let currentUnit: UnitSystem = "imperial";
+
+const latestRainViewerFrame = (metadata: RainViewerWeatherMaps) => {
+  const frames = [...(metadata.radar?.past ?? []), ...(metadata.radar?.nowcast ?? [])];
+  return frames.sort((a, b) => a.time - b.time).at(-1);
+};
+
+const refreshRadarLayer = () => {
+  if (!map || radarLayerRequest || (radarLayer && Date.now() - radarLayerLoadedAt < rainViewerRefreshMs)) return;
+
+  radarLayerRequest = (async () => {
+    const metadata = await fetchJson<RainViewerWeatherMaps>(rainViewerMapsUrl);
+    const frame = latestRainViewerFrame(metadata);
+    if (!map || !metadata.host || !frame?.path) return;
+
+    const nextLayer = L.tileLayer(`${metadata.host}${frame.path}/256/{z}/{x}/{y}/2/1_1.png`, {
+      attribution: '<a href="https://www.rainviewer.com/" rel="noopener">RainViewer</a>',
+      className: "weather-radar-tile",
+      maxNativeZoom: 7,
+      opacity: 0.72,
+      tileSize: 256
+    });
+
+    radarLayer?.remove();
+    radarLayer = nextLayer;
+    radarLayer.addTo(map);
+    radarLayerLoadedAt = Date.now();
+  })()
+    .catch(() => {
+      // Radar is supplementary; keep the map usable if the public tile feed is unavailable.
+    })
+    .finally(() => {
+      radarLayerRequest = null;
+    });
+};
 
 const renderMap = (latitude: number, longitude: number, label: string) => {
   const mapElement = document.getElementById("weather-map");
@@ -299,9 +351,12 @@ const renderMap = (latitude: number, longitude: number, label: string) => {
       zoomControl: true
     });
     L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
-      attribution: "&copy; OpenStreetMap contributors"
+      attribution: "&copy; OpenStreetMap contributors",
+      className: "weather-base-tile"
     }).addTo(map);
   }
+
+  refreshRadarLayer();
 
   marker?.remove();
   marker = L.circleMarker([latitude, longitude], {

--- a/src/styles/apps.css
+++ b/src/styles/apps.css
@@ -878,8 +878,12 @@
   min-height: 19rem;
 }
 
-.weather-map .leaflet-tile {
+.weather-map .weather-base-tile .leaflet-tile {
   filter: var(--weather-map-filter);
+}
+
+.weather-map .weather-radar-tile .leaflet-tile {
+  filter: none;
 }
 
 .weather-map .leaflet-control-container {


### PR DESCRIPTION
## Summary
- add a RainViewer radar overlay to the existing Leaflet weather map
- keep OpenStreetMap base tiles styled separately from radar tiles so radar colors render correctly
- include RainViewer attribution and refresh radar metadata on a short cache window

## Validation
- npm run typecheck
- npm run build
- rendered QA on http://127.0.0.1:5173/weather/ with Playwright: verified radar tiles load, attribution is present, search recentering keeps the overlay active, and the mobile map still renders
